### PR TITLE
Легенда

### DIFF
--- a/cgraphics/cvideo_qt.cc
+++ b/cgraphics/cvideo_qt.cc
@@ -138,7 +138,8 @@ void CVideo_Qt::GetStringImageSize(const char *string,uint32_t &width,uint32_t &
  QPainter qPainter(qPixmap_Ptr.get());
  QFontMetrics qFontMetrics(qPainter.font());
  QRect qRect=qFontMetrics.boundingRect(string);
- width=qRect.width();
+// width=qRect.width();
+ width = qFontMetrics.horizontalAdvance(string);
  height=qRect.height();
 }
 //----------------------------------------------------------------------------------------------------


### PR DESCRIPTION
Начиная с Qt 5.11 для определения ширины текста вместо width() надо иcпользовать метод horizontalAdvance() класса QFontMetrics.

width() - устарело.

Иначе легенды графиков будут криво обрезаться (